### PR TITLE
Add AssemblyLoadContext

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -11,10 +11,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
+    - name: Setup .NET Core 3
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
     - name: Restore dependencies

--- a/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/Assembly.Methods.cs
+++ b/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/Assembly.Methods.cs
@@ -2,6 +2,8 @@
 
 namespace CompulsoryCow.AssemblyAbstractions
 {
+    /// <summary>Abstract <see cref="System.Reflection.Assembly"/>.
+    /// </summary>
     public partial class Assembly
     {
         public System.Reflection.AssemblyName GetName()

--- a/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/Assembly.Set.cs
+++ b/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/Assembly.Set.cs
@@ -25,5 +25,14 @@ namespace CompulsoryCow.AssemblyAbstractions
         }
 
         #endregion
+
+        /// <summary>Convert a <see cref="System.Reflection.Assembly"/> to a <see cref="IAssembly"/>.
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <returns></returns>
+        public static IAssembly ToIAssembly( System.Reflection.Assembly assembly)
+        {
+            return new Assembly(assembly);
+        }
     }
 }

--- a/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/Assembly.cs
+++ b/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/Assembly.cs
@@ -2,9 +2,16 @@
 
 namespace CompulsoryCow.AssemblyAbstractions
 {
+    /// <summary>Abstract <see cref="System.Reflection.Assembly"/>.
+    /// </summary>
     public partial class Assembly: IAssembly
     {
         private System.Reflection.Assembly _systemReflectionAssembly;
+
+        internal Assembly(System.Reflection.Assembly assembly)
+        {
+            _systemReflectionAssembly = assembly;
+        }
 
         /// <inheritdoc />
         [Obsolete("Use IAssemblyFactory.GetAssembly instead.", true)]

--- a/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/AssemblyFactory.cs
+++ b/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/AssemblyFactory.cs
@@ -24,33 +24,29 @@
         /// <inheritdoc />
         public IAssembly GetAssembly(System.Type type)
         {
-            var res = new Assembly();
-            res.SetAssembly(() => System.Reflection.Assembly.GetAssembly(type));
-            return res;
+            return new Assembly(
+                System.Reflection.Assembly.GetAssembly(type));
         }
 
         /// <inheritdoc />
         public IAssembly GetExecutingAssembly()
         {
-            var res = new Assembly();
-            res.SetAssembly(() => System.Reflection.Assembly.GetExecutingAssembly());
-            return res;
+            return new Assembly(
+                System.Reflection.Assembly.GetExecutingAssembly());
         }
 
         /// <inheritdoc />
         public IAssembly LoadFile(string pathFile)
         {
-            var res = new Assembly();
-            res.SetAssembly(() => System.Reflection.Assembly.LoadFile(pathFile));
-            return res;
+            return new Assembly(
+                System.Reflection.Assembly.LoadFile(pathFile));
         }
 
         /// <inheritdoc />
         public IAssembly LoadFrom(string pathFile)
         {
-            var res = new Assembly();
-            res.SetAssembly(() => System.Reflection.Assembly.LoadFrom(pathFile));
-            return res;
+            return new Assembly(
+                System.Reflection.Assembly.LoadFrom(pathFile));
         }
 
         #endregion

--- a/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/AssemblyLoadContext.cs
+++ b/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/AssemblyLoadContext.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+
+namespace CompulsoryCow.AssemblyAbstractions
+{
+    /// <summary>Abstract <see cref="System.Runtime.Loader.AssemblyLoadContext"/>.
+    /// </summary>
+    public class AssemblyLoadContext : IAssemblyLoadContext
+    {
+        private readonly System.Runtime.Loader.AssemblyLoadContext assemblyLoadContext;
+
+        /// <inheritdoc />
+        public AssemblyLoadContext(System.Runtime.Loader.AssemblyLoadContext assemblyLoadContext)
+        {
+            this.assemblyLoadContext = assemblyLoadContext;
+        }
+
+        /// <inheritdoc />
+        public IAssembly LoadFromStream(Stream assembly)
+        {
+            return Assembly.ToIAssembly(
+                assemblyLoadContext.LoadFromStream(assembly)
+            );
+        }
+    }
+}

--- a/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/AssemblyLoadContextFactory.cs
+++ b/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/AssemblyLoadContextFactory.cs
@@ -1,0 +1,15 @@
+﻿namespace CompulsoryCow.AssemblyAbstractions
+{
+    /// <summary>Create a <see cref="AssemblyLoadContext"/>.
+    /// </summary>
+    public class AssemblyLoadContextFactory : IAssemblyLoadContextFactory
+    {
+        /// <inheritdoc/>
+        public IAssemblyLoadContext Create(string name, bool isCollectible = false)
+        {
+            var ass = new System.Runtime.Loader.AssemblyLoadContext(name, isCollectible);
+            var ret = new AssemblyLoadContext(ass);
+            return ret;
+        }
+    }
+}

--- a/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/CHANGELOG.md
+++ b/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6]
+Breaking change.
+Change from netstandard2.0 to net5.0 as it was needed to get a method to work. (can't remember which')
+
+Add AssemblyLoadContext.
+Add AssemblyLoadContextFactory.
+
 ## [0.5]
 Add LoadFrom constructor.
 Fix bug where LoadFile called LoadFrom internally.

--- a/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions.csproj
+++ b/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
-  <AssemblyVersion>0.5.0</AssemblyVersion>
-  <FileVersion>0.5.0</FileVersion>
-  <Version>0.5.0</Version>
+  <AssemblyVersion>0.6.0</AssemblyVersion>
+  <FileVersion>0.6.0</FileVersion>
+  <Version>0.6.0</Version>
 
   <Authors>LosManos</Authors>
   <Company>LosManos</Company>

--- a/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/IAssemblyLoadContext.cs
+++ b/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/IAssemblyLoadContext.cs
@@ -1,0 +1,15 @@
+﻿using System.IO;
+
+namespace CompulsoryCow.AssemblyAbstractions
+{
+    /// <summary>See <see cref="System.Runtime.Loader.AssemblyLoadContext"/>.
+    /// </summary>
+    public interface IAssemblyLoadContext
+    {
+        /// <summary>See <see cref="System.Runtime.Loader.AssemblyLoadContext.LoadFromStream(Stream)"/>.
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <returns></returns>
+        public IAssembly LoadFromStream(Stream assembly);
+    }
+}

--- a/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/IAssemblyLoadContextFactory.cs
+++ b/CompulsoryCow.AssemblyAbstractions/CompulsoryCow.AssemblyAbstractions/IAssemblyLoadContextFactory.cs
@@ -1,0 +1,12 @@
+﻿namespace CompulsoryCow.AssemblyAbstractions
+{
+    public interface IAssemblyLoadContextFactory
+    {
+        /// <summary>Create an <see cref="IAssemblyLoadContext"/>.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="isCollectible"></param>
+        /// <returns></returns>
+        IAssemblyLoadContext Create(string name, bool isCollectible = false);
+    }
+}

--- a/CompulsoryCow.AssemblyAbstractions/Tests/CompulsoryCow.AssemblyAbstractions.Unit.Tests/Assembly.Methods.Tests.cs
+++ b/CompulsoryCow.AssemblyAbstractions/Tests/CompulsoryCow.AssemblyAbstractions.Unit.Tests/Assembly.Methods.Tests.cs
@@ -56,10 +56,10 @@ namespace CompulsoryCow.AssemblyAbstractions.Unit.Tests
 
             var methods = typeof(Assembly)
                 .GetMethods()
-                .Where(m => m.IsConstructor == false)
                 .Where(m =>
                     m.IsConstructor == false &&
-                    m.Name.StartsWith("get_") == false &&
+                    IsProperty( m) == false &&
+                    m.IsStatic == false &&
                     objectMethods.Contains(m.Name) == false &&
                     testingMethods.Contains(m.Name) == false
                 );
@@ -74,6 +74,11 @@ namespace CompulsoryCow.AssemblyAbstractions.Unit.Tests
                 true,
                 $"all methods {string.Join(",", methods.Select(m => m.Name))} should be virtual"
             );
+        }
+
+        private static bool IsProperty(System.Reflection.MethodInfo m)
+        {
+            return m.Name.StartsWith("get_");
         }
 
     }

--- a/CompulsoryCow.AssemblyAbstractions/Tests/CompulsoryCow.AssemblyAbstractions.Unit.Tests/AssemblyFactory.Tests.cs
+++ b/CompulsoryCow.AssemblyAbstractions/Tests/CompulsoryCow.AssemblyAbstractions.Unit.Tests/AssemblyFactory.Tests.cs
@@ -66,7 +66,7 @@ namespace CompulsoryCow.AssemblyAbstractions.Unit.Tests
             var res = sut.GetExecutingAssembly();
 
             //  Assert.
-            res.FullName.Should().Be("CompulsoryCow.AssemblyAbstractions, Version=0.5.0.0, Culture=neutral, PublicKeyToken=null");
+            res.FullName.Should().Be("CompulsoryCow.AssemblyAbstractions, Version=0.6.0.0, Culture=neutral, PublicKeyToken=null");
         }
 
         [Fact]

--- a/CompulsoryCow.AssemblyAbstractions/Tests/CompulsoryCow.AssemblyAbstractions.Unit.Tests/AssemblyLoadContext.Tests.cs
+++ b/CompulsoryCow.AssemblyAbstractions/Tests/CompulsoryCow.AssemblyAbstractions.Unit.Tests/AssemblyLoadContext.Tests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace CompulsoryCow.AssemblyAbstractions.Unit.Tests
+{
+    /// <summary>This class contains tests of the (static) constructors
+    /// in <see cref="System.Reflection.Assembly"/>
+    /// which in AssemblyAbstractions is moved 
+    /// from Assembly to AssemblyFactory
+    /// as static constructors are impossible(?) to mock.
+    /// </summary>
+    public class AssemblyLoadContextTests
+    {
+        [Fact]
+        public void AllMethodsShouldBeMockable()
+        {
+            // These methods are out of our control.
+            var objectMethods = new[]
+            {
+                    nameof(AssemblyFactory.Equals),
+                    nameof(AssemblyFactory.GetHashCode),
+                    nameof(AssemblyFactory.GetType),
+                    nameof(AssemblyFactory.ToString),
+            };
+
+            var methods = typeof(AssemblyLoadContext)
+                .GetMethods()
+                .Where(m => m.IsConstructor == false)
+                .Where(m => objectMethods.Contains(m.Name) == false
+                );
+
+            var res = methods
+                .Select(m => m.IsVirtual);
+
+            //  Act.
+            res.Count().Should().Be(1, "Sanity check we know how many methods we have.");
+
+            res.Should().AllBeEquivalentTo(
+                true,
+                $"all methods {string.Join(",", methods.Select(m => m.Name))} should be virtual"
+            );
+        }
+
+        [Fact]
+        public void LoadFromStream_Stream_ShouldMimicSystem()
+        {
+            var alc = new System.Runtime.Loader.AssemblyLoadContext("any");
+            var sut = new AssemblyLoadContext(alc);
+
+            var compiledAssembly = Compile(SourceCode);
+            using (var asm = new MemoryStream(compiledAssembly))
+            {
+                //  Act.
+                var res = sut.LoadFromStream(asm);
+
+                //  Assert.
+                res.FullName.Should().Be("Any.dll, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
+            }
+        }
+
+        private static byte[] Compile(string sourceCode)
+        {
+            using (var peStream = new MemoryStream())
+            {
+                var result = GenerateCode(sourceCode).Emit(peStream);
+                if (result.Success == false)
+                {
+                    throw new Exception(string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.ToString())));
+                }
+                peStream.Seek(0, SeekOrigin.Begin);
+                return peStream.ToArray();
+            }
+        }
+
+        private static CSharpCompilation GenerateCode(string sourceCode)
+        {
+            var codeString = SourceText.From(sourceCode);
+            var options = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp8);
+
+            var parsedSyntaxTree = SyntaxFactory.ParseSyntaxTree(codeString, options);
+
+            return CSharpCompilation.Create("Any.dll",
+                new[] { parsedSyntaxTree },
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                    optimizationLevel: OptimizationLevel.Debug,
+                    assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default));
+        }
+
+        private const string SourceCode = @"
+namespace AnyNameSpace
+{
+}";
+    }
+}

--- a/CompulsoryCow.AssemblyAbstractions/Tests/CompulsoryCow.AssemblyAbstractions.Unit.Tests/CompulsoryCow.AssemblyAbstractions.Unit.Tests.csproj
+++ b/CompulsoryCow.AssemblyAbstractions/Tests/CompulsoryCow.AssemblyAbstractions.Unit.Tests/CompulsoryCow.AssemblyAbstractions.Unit.Tests.csproj
@@ -1,13 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/CompulsoryCow.sln
+++ b/CompulsoryCow.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		HowTo-MergeToMasterAtPublicRepository.md = HowTo-MergeToMasterAtPublicRepository.md
 		license.txt = license.txt
 		README.md = README.md
+		Release.md = Release.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{B6BA6D69-846B-4AB1-B9D5-0D2CA3A7FAC8}"


### PR DESCRIPTION
This commit is a breaking change
as it updates the framework from netstandard2.0 to net5.0.

This commit adds AssemlbyLoadContext
and matching factory.