### PR TITLE
Update all Core3 to Dotnet6

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core 3
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v3
+    - name: Setup .NET Core 6
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 3.1.x
-    - name: Setup .NET 5
-      uses: actions/setup-dotnet@v1
+        dotnet-version: 6.x
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.x
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core 3
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v3
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 6.x
     - name: Setup .NET 5
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/CompulsoryCow.AreEqual/Tests/CompulsoryCow.AreEqual.Unit.Tests/CompulsoryCow.AreEqual.Unit.Tests.csproj
+++ b/CompulsoryCow.AreEqual/Tests/CompulsoryCow.AreEqual.Unit.Tests/CompulsoryCow.AreEqual.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/CompulsoryCow.CharacterSeparated/Tests/CompulsoryCow.CharacterSeparated.Unit.Tests/CompulsoryCow.CharacterSeparated.Unit.Tests.csproj
+++ b/CompulsoryCow.CharacterSeparated/Tests/CompulsoryCow.CharacterSeparated.Unit.Tests/CompulsoryCow.CharacterSeparated.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CompulsoryCow.DateTimeAbstractions/Tests/CompulsoryCow.DateTimeAbstractions.Unit.Tests/CompulsoryCow.DateTimeAbstractions.Unit.Tests.csproj
+++ b/CompulsoryCow.DateTimeAbstractions/Tests/CompulsoryCow.DateTimeAbstractions.Unit.Tests/CompulsoryCow.DateTimeAbstractions.Unit.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CompulsoryCow.DateTimeAbstractions/Tests/CompulsoryCow.DateTimeAbstractions.Unit.Tests/DateTime.InstanceMethod.Tests.cs
+++ b/CompulsoryCow.DateTimeAbstractions/Tests/CompulsoryCow.DateTimeAbstractions.Unit.Tests/DateTime.InstanceMethod.Tests.cs
@@ -530,10 +530,7 @@ namespace CompulsoryCow.DateTimeAbstractions.Unit.Tests
             expectedResult.Should().Equal(new[]
             {
                 "28/07/2009",
-                "28/07/09",
-                "28.07.09",
-                "28-07-09",
-                "2009-07-28",
+                "28 juil. 2009",
             }, "Sanity check we have setup the test correctly");
 
             //  Act.

--- a/CompulsoryCow.DeSerialiser/Tests/CompulsoryCow.DeSerialiser.Unit.Tests/CompulsoryCow.DeSerialiser.Unit.Tests.csproj
+++ b/CompulsoryCow.DeSerialiser/Tests/CompulsoryCow.DeSerialiser.Unit.Tests/CompulsoryCow.DeSerialiser.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CompulsoryCow.DeSerialiser/Tests/CompulsoryCow.DeSerialiser.Unit.Tests/SerialiserTest.cs
+++ b/CompulsoryCow.DeSerialiser/Tests/CompulsoryCow.DeSerialiser.Unit.Tests/SerialiserTest.cs
@@ -22,7 +22,7 @@ namespace SerialiserTest
             res.DocumentElement.Name.Should().Be("SimpleClass");
             res.ChildNodes.Count.Should().Be(2);
             res.InnerXml.Should().Be(
-                "<?xml version=\"1.0\"?><SimpleClass xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><ID>1</ID><Name>asdf</Name></SimpleClass>" 
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?><SimpleClass xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><ID>1</ID><Name>asdf</Name></SimpleClass>" 
             );
         }
 
@@ -39,7 +39,7 @@ namespace SerialiserTest
 
             res.Should().NotBeNull();
             res.InnerXml.Should().Be(
-                "<?xml version=\"1.0\"?><ArrayOfSimpleClass xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><SimpleClass><ID>1</ID><Name>asdf</Name></SimpleClass><SimpleClass><ID>2</ID></SimpleClass></ArrayOfSimpleClass>"
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?><ArrayOfSimpleClass xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><SimpleClass><ID>1</ID><Name>asdf</Name></SimpleClass><SimpleClass><ID>2</ID></SimpleClass></ArrayOfSimpleClass>"
             );
         }
     }

--- a/CompulsoryCow.IsEqualsImplemented/Tests/CompulsoryCow.IsEqualsImplemented.Unit.Tests/CompulsoryCow.IsEqualsImplemented.Unit.Tests.csproj
+++ b/CompulsoryCow.IsEqualsImplemented/Tests/CompulsoryCow.IsEqualsImplemented.Unit.Tests/CompulsoryCow.IsEqualsImplemented.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CompulsoryCow.IsEqualsImplemented/Tests/IsEqualsImplementedAssemblyNoDefinitionAtAll/IsEqualsImplementedAssemblyNoDefinitionAtAll.csproj
+++ b/CompulsoryCow.IsEqualsImplemented/Tests/IsEqualsImplementedAssemblyNoDefinitionAtAll/IsEqualsImplementedAssemblyNoDefinitionAtAll.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/CompulsoryCow.IsEqualsImplemented/Tests/IsEqualsImplementedAssemblyNotOk/IsEqualsImplementedAssemblyNotOk.csproj
+++ b/CompulsoryCow.IsEqualsImplemented/Tests/IsEqualsImplementedAssemblyNotOk/IsEqualsImplementedAssemblyNotOk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/CompulsoryCow.IsEqualsImplemented/Tests/IsEqualsImplementedAssemblyOk/IsEqualsImplementedAssemblyOk.csproj
+++ b/CompulsoryCow.IsEqualsImplemented/Tests/IsEqualsImplementedAssemblyOk/IsEqualsImplementedAssemblyOk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/CompulsoryCow.Meta/Tests/CompulsoryCow.Meta.Unit.Tests/CompulsoryCow.Meta.Unit.Tests.csproj
+++ b/CompulsoryCow.Meta/Tests/CompulsoryCow.Meta.Unit.Tests/CompulsoryCow.Meta.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CompulsoryCow.Permutation/Tests/CompulsoryCow.Permutation.Unit.Tests/CompulsoryCow.Permutation.Unit.Tests.csproj
+++ b/CompulsoryCow.Permutation/Tests/CompulsoryCow.Permutation.Unit.Tests/CompulsoryCow.Permutation.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CompulsoryCow.ReachIn/Tests/CompulsoryCow.ReachIn.Unit.Tests/CompulsoryCow.ReachIn.Unit.Tests.csproj
+++ b/CompulsoryCow.ReachIn/Tests/CompulsoryCow.ReachIn.Unit.Tests/CompulsoryCow.ReachIn.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CompulsoryCow.ReachIn/Tests/CompulsoryCow.ReachPrivateIn.Unit.Tests/CompulsoryCow.ReachPrivateIn.Unit.Tests.csproj
+++ b/CompulsoryCow.ReachIn/Tests/CompulsoryCow.ReachPrivateIn.Unit.Tests/CompulsoryCow.ReachPrivateIn.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CompulsoryCow.StringExtensions/Tests/CompulsoryCow.StringExtensions.Unit.Tests/CompulsoryCow.StringExtensions.Unit.Tests.csproj
+++ b/CompulsoryCow.StringExtensions/Tests/CompulsoryCow.StringExtensions.Unit.Tests/CompulsoryCow.StringExtensions.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Release.md
+++ b/Release.md
@@ -1,6 +1,9 @@
 CompulsoryCow - Release notes
 ====================
 
+### Version 3.0
+Updated all dotnet core 3 to dotnet6.
+
 ### Version 2.5.0
 Added method Meta.GetPublicProperties.
 


### PR DESCRIPTION
This commit updates all Core3 code to Dotnet 6

This commit contains no functional change.

This commis is part of #50.