### PR TITLE
(Permutation)Add ToTestData method to make it easier to write test data

### DIFF
--- a/CompulsoryCow.Permutation/CompulsoryCow.Permutation/CHANGELOG.md
+++ b/CompulsoryCow.Permutation/CompulsoryCow.Permutation/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0]
+Update to Dotnet6 but still Dotnetstandard 2.
+Permutate Enum.
+Permuate bool.
+Change Permutate signature.
+ToTestData function created.
+
 ## [0.2.0]
 Permutate function created.
 Scroll function created.

--- a/CompulsoryCow.Permutation/CompulsoryCow.Permutation/CompulsoryCow.Permutation.csproj
+++ b/CompulsoryCow.Permutation/CompulsoryCow.Permutation/CompulsoryCow.Permutation.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.2.0</Version>
-    <AssemblyVersion>0.2.0</AssemblyVersion>
-    <FileVersion>0.2.0</FileVersion>
+    <Version>0.3.0</Version>
+    <AssemblyVersion>0.3.0</AssemblyVersion>
+    <FileVersion>0.3.0</FileVersion>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 

--- a/CompulsoryCow.Permutation/CompulsoryCow.Permutation/CompulsoryCow.Permutation.nuspec
+++ b/CompulsoryCow.Permutation/CompulsoryCow.Permutation/CompulsoryCow.Permutation.nuspec
@@ -2,10 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <!-- Continuously updated elements -->
-        <version>0.2.0</version>
+        <version>0.3.0</version>
         <releaseNotes>
-            Permutate function created.
-            Scroll function created.
+            ToTestData function created.
         </releaseNotes>
 
         <!-- Required elements -->

--- a/CompulsoryCow.Permutation/CompulsoryCow.Permutation/IEnumerableIEnumerableObjectExtensions.cs
+++ b/CompulsoryCow.Permutation/CompulsoryCow.Permutation/IEnumerableIEnumerableObjectExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CompulsoryCow.Permutation;
+
+public static class IEnumerableIEnumerableObjectExtensions
+{
+    /// <summary>Helper method for returning
+    /// data from a data driven test that takes an
+    /// IEnumerable &lt; object[] &gt; dataset.
+    /// </summary>
+    /// <param name="data"></param>
+    /// <returns></returns>
+    public static IEnumerable<object[]> ToTestData(
+        this IEnumerable<IEnumerable<object>> data
+        )
+    {
+        return data
+            .Select(d => d.ToArray());
+    }
+}

--- a/CompulsoryCow.Permutation/Tests/CompulsoryCow.Permutation.Unit.Tests/IEnumerableIEnumerableObjectExtensionTests.cs
+++ b/CompulsoryCow.Permutation/Tests/CompulsoryCow.Permutation.Unit.Tests/IEnumerableIEnumerableObjectExtensionTests.cs
@@ -1,0 +1,72 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace CompulsoryCow.Permutation.Unit.Tests;
+
+public class IEnumerableIEnumerableObjectExtensionTests : IClassFixture<Context>
+{
+    private readonly Context context;
+
+    public IEnumerableIEnumerableObjectExtensionTests(Context contextData)
+    {
+        this.context = contextData;
+    }
+
+    public static IEnumerable<object[]> TestData()
+    {
+        IEnumerable<IEnumerable<object>> res = Permutation.Permutate(
+            new object[] { 1, 2 },
+            new object[] { "a", "b" }
+        );
+
+        //  This line is the test, `ToTestData`.
+        return res.ToTestData();
+    }
+
+    /// <summary>This test makes sure we run through all permuataions
+    /// of the test data. It is done by recording all test data and then verify
+    /// it against a known list. The verification/assert is done in the context's
+    /// Dispose method.
+    /// </summary>
+    /// <param name="n"></param>
+    /// <param name="s"></param>
+    [Theory]
+    [MemberData(nameof(TestData))]
+    public void Should_return_all_permutations(int n, string s)
+    {
+        context.Use((n, s));
+
+        //  Assert is done in the Context Dispose.
+    }
+}
+
+public class Context : IDisposable
+{
+    // Since we cannot know in which order the testdata is received
+    // we have a list of all possible testdata and tick them off
+    // for every test. That way we can verify all testdata are passed uniquely.
+    // Finally we use the Dispose method, that runs after all tests in the class,
+    // to verify all testdata are used up.
+    private readonly List<(int, string)> expectedTestdata = new List<(int, string)>
+    {
+        (1,"a"),
+        (1,"b"),
+        (2,"a"),
+        (2,"b"),
+    };
+
+    private readonly List<(int, string)> actualTestdata = new List<(int, string)>();
+
+    public void Dispose()
+    {
+        actualTestdata.Should().BeEquivalentTo(expectedTestdata, 
+            "All testdata should be accounted for, no more, no less.");
+    }
+
+    public void Use((int,string) testdata)
+    {
+        actualTestdata.Add(testdata);
+    }
+}


### PR DESCRIPTION
This commit adds a method that should make it easier to write test data. Before the test data was written something like:
```
public static IEnumerable<object[]> Variants()
{
    return Permutation.Permutate(
            Permutation.AllIEnumItems<WebPage>(),
            Permutation.AllBools(),
            Permutation.AllBools()
        )
        .Select(data =>
        {
            return new[] {
                data.First(),
                data.Skip(1).First(),
                data.Skip(2).First()
            };
        });
}
```
after this commit it looks like
```
public static IEnumerable<object[]> TestData()
{
    IEnumerable<IEnumerable<object>> res = Permutation.Permutate(
        new object[] { 1, 2 },
        new object[] { "a", "b" }
    );

    //  This line is the test, `ToTestData`.
    return res.ToTestData();
}
```
Okok, the testdata differs in above example. But it is clear that the last linq Select call is replaced with a simple ToTestData call.

This commit is the first part of #62.
There are some refining of existing test to come.