### PR TITLE
DeSerialiser: v.0.3.1 Include dotnetstandard2.1 in nuget package

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.x
-    - name: Setup .NET 5
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x

--- a/CompulsoryCow.DeSerialiser/CompulsoryCow.DeSerialiser/CompulsoryCow.DeSerialiser.csproj
+++ b/CompulsoryCow.DeSerialiser/CompulsoryCow.DeSerialiser/CompulsoryCow.DeSerialiser.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
-    <AssemblyVersion>0.3.0</AssemblyVersion>
-    <FileVersion>0.3.0</FileVersion>
-    <Version>0.3.0</Version>
+    <AssemblyVersion>0.3.1</AssemblyVersion>
+    <FileVersion>0.3.1</FileVersion>
+    <Version>0.3.1</Version>
 
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/CompulsoryCow.DeSerialiser/CompulsoryCow.DeSerialiser/CompulsoryCow.DeSerialiser.nuspec
+++ b/CompulsoryCow.DeSerialiser/CompulsoryCow.DeSerialiser/CompulsoryCow.DeSerialiser.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <!-- Continuously updated elements -->
-        <version>0.2.0</version>
+        <version>0.3.1</version>
         <releaseNotes>
             Moved to a project of its own.
             Renamed DeSerializer to DeSerialiser.
@@ -23,7 +23,7 @@
         <license type="file">license.txt</license>
         <summary>A library for serialising and deserialising dotnet objects.</summary>
         <dependencies>
-            <group targetFramework=".NETStandard2.0">
+            <group targetFramework=".NETStandard2.1">
                 <dependency id="CompulsoryCow.Meta" version="3.0.0" exclude="Build,Analyzers" />
             </group>
         </dependencies>
@@ -31,6 +31,6 @@
     <files>
         <file src="..\..\license.txt" target="" />
         <file src="CHANGELOG.md" target="" />
-        <file src="bin\Release\netstandard2.0\*.dll" target="lib\netstandard2.0" />
+        <file src="bin\Release\netstandard2.1\*.dll" target="lib\netstandard2.1" />
     </files>
 </package>

--- a/CompulsoryCow.DeSerialiser/CompulsoryCow.DeSerialiser/Release.md
+++ b/CompulsoryCow.DeSerialiser/CompulsoryCow.DeSerialiser/Release.md
@@ -1,5 +1,10 @@
 CompulsoryCow.DeSerializer- Release notes
 ====================
 
+### Version 0.3.1
+Get rid of build warnings
+Update to dotnetstandard2.1
+Update build.
+
 ### Version 0.2.0
 Moved to a project of its own.

--- a/Howto-Release.md
+++ b/Howto-Release.md
@@ -12,5 +12,6 @@ The project's changelog should have a new entry.
 The solution's release.md should have a neew entry.
 
 ## Nuget package
+The nuget nuspec file has en entry <releaseNotes> that should be updated.
 The build in github manages publishing to nuget.
 It might take a while for nuget to index the new package.


### PR DESCRIPTION
When updating to dotnetstandard2.1
I had forgotten to include the 2.1 files.

This commit piggy backs #72.