### PR TITLE
ReachIn:Get rid of build warnings

### DIFF
--- a/CompulsoryCow.ReachIn/CompulsoryCow.ReachIn/ReachIn.cs
+++ b/CompulsoryCow.ReachIn/CompulsoryCow.ReachIn/ReachIn.cs
@@ -7,7 +7,7 @@ namespace CompulsoryCow.ReachIn;
 
 public class ReachIn : DynamicObject
 {
-    private readonly object _obj;
+    private readonly object? _obj;
     private readonly Type _type;
 
     public ReachIn(Type type)
@@ -22,7 +22,7 @@ public class ReachIn : DynamicObject
         _type = obj.GetType();
     }
 
-    public override bool TryGetMember(GetMemberBinder binder, out object result)
+    public override bool TryGetMember(GetMemberBinder binder, out object? result)
     {
         var member = GetMemberOrThrow(_type, binder.Name);
         switch (member.MemberType)
@@ -52,7 +52,7 @@ public class ReachIn : DynamicObject
         }
     }
 
-    public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+    public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object? result)
     {
         var member = GetMemberOrThrow(_type, binder.Name);
         switch (member.MemberType)

--- a/CompulsoryCow.ReachIn/CompulsoryCow.ReachIn/ReachPrivateIn.cs
+++ b/CompulsoryCow.ReachIn/CompulsoryCow.ReachIn/ReachPrivateIn.cs
@@ -73,7 +73,7 @@ public class ReachPrivateIn : DynamicObject
 /// <summary>This class should not be used. Use <see cref="ReachIn"/> instead.
 /// </summary>
 [Obsolete("Use ReachIn instead.", error: false)]
-public class ReachPrivateIn<T> : DynamicObject
+public class ReachPrivateIn<T> : DynamicObject where T : notnull
 {
     private T sut;
 
@@ -84,12 +84,12 @@ public class ReachPrivateIn<T> : DynamicObject
 
     public override bool TryGetMember(GetMemberBinder binder, out object result)
     {
-        var property = 
+        var property =
             Meta.GetPrivateProperty(sut, binder.Name) ??
             Meta.GetPrivateStaticProperty(sut.GetType(), binder.Name);
         if (property != null)
         {
-            result = property.GetValue(sut,null);
+            result = property.GetValue(sut, null);
             return true;
         }
 
@@ -119,12 +119,12 @@ public class ReachPrivateIn<T> : DynamicObject
 
     public override bool TrySetMember(SetMemberBinder binder, object value)
     {
-        var property = 
+        var property =
             Meta.GetPrivateProperty(sut, binder.Name) ??
             Meta.GetPrivateStaticProperty(sut.GetType(), binder.Name);
         if (property != null)
         {
-            property.SetValue(sut, value,null);
+            property.SetValue(sut, value, null);
             return true;
         }
 

--- a/CompulsoryCow.ReachIn/Tests/CompulsoryCow.ReachIn.Unit.Tests/ReachInGetMemberOrThrowTest.MyBaseClass.cs
+++ b/CompulsoryCow.ReachIn/Tests/CompulsoryCow.ReachIn.Unit.Tests/ReachInGetMemberOrThrowTest.MyBaseClass.cs
@@ -1,4 +1,9 @@
-﻿namespace CompulsoryCow.ReachIn.Tests;
+﻿#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable CS0169 // Field is never used
+#pragma warning disable CS0649 // Field is never assigned to and will always have its default value
+
+namespace CompulsoryCow.ReachIn.Tests;
 
 public partial class ReachInGetMemberOrThrowTest
 {

--- a/CompulsoryCow.ReachIn/Tests/CompulsoryCow.ReachPrivateIn.Unit.Tests/ReachPrivateInStaticTest.cs
+++ b/CompulsoryCow.ReachIn/Tests/CompulsoryCow.ReachPrivateIn.Unit.Tests/ReachPrivateInStaticTest.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// The whole `ReachPrivateIn` is obsolete. So to get rid of build warnings we mark all tests as obsolete, 
+// until we remove the testee all together.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+using System;
 using CompulsoryCow.ReachIn;
 using Xunit;
 

--- a/CompulsoryCow.ReachIn/Tests/CompulsoryCow.ReachPrivateIn.Unit.Tests/ReachPrivateInTest.cs
+++ b/CompulsoryCow.ReachIn/Tests/CompulsoryCow.ReachPrivateIn.Unit.Tests/ReachPrivateInTest.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// The whole `ReachPrivateIn` is obsolete. So to get rid of build warnings we mark all tests as obsolete, 
+// until we remove the testee all together.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+using System;
 using CompulsoryCow.ReachIn;
 using Xunit;
 

--- a/CompulsoryCow.ReachIn/Tests/ReachInTestDotnetFramework/MyBaseClass.cs
+++ b/CompulsoryCow.ReachIn/Tests/ReachInTestDotnetFramework/MyBaseClass.cs
@@ -1,4 +1,10 @@
-﻿namespace ReachInTestDotnetFramework
+﻿#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable CS0169 // Field is never used
+#pragma warning disable CS0414 // Field is assigned but never used
+#pragma warning disable CS0649 // Field is never assigned to and will always have its default value
+
+namespace ReachInTestDotnetFramework
 {
     public class MyBaseClass
     {

--- a/CompulsoryCow.ReachIn/Tests/ReachInTestDotnetFramework/MyBaseClassWithTypes.cs
+++ b/CompulsoryCow.ReachIn/Tests/ReachInTestDotnetFramework/MyBaseClassWithTypes.cs
@@ -1,4 +1,7 @@
-﻿namespace ReachInTestDotnetFramework
+﻿#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable CS0169 // Field is never used
+
+namespace ReachInTestDotnetFramework
 {
     public class MyBaseClassWithTypes
     {

--- a/CompulsoryCow.ReachIn/Tests/ReachInTestDotnetFramework/MyPublicClass.cs
+++ b/CompulsoryCow.ReachIn/Tests/ReachInTestDotnetFramework/MyPublicClass.cs
@@ -1,4 +1,9 @@
-﻿namespace ReachInTestDotnetFramework
+﻿#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable CS0169 // Field is never used
+#pragma warning disable CS0649 // Field is never assigned to and will always have its default value
+
+namespace ReachInTestDotnetFramework
 {
     public class MyPublicClass : MyBaseClass
     {

--- a/CompulsoryCow.ReachIn/Tests/ReachInTestDotnetFramework/MyPublicStaticClass.cs
+++ b/CompulsoryCow.ReachIn/Tests/ReachInTestDotnetFramework/MyPublicStaticClass.cs
@@ -1,4 +1,10 @@
-﻿namespace ReachInTestDotnetFramework
+﻿#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable CS0169 // Field is never used
+#pragma warning disable CS0414 // Field is assigned but never used
+#pragma warning disable CS0649 // Field is never assigned to and will always have its default value
+
+namespace ReachInTestDotnetFramework
 {
     public static class MyPublicStaticClass
     {

--- a/CompulsoryCow.ReachIn/Tests/ReachInTestDotnetFramework/MyStaticBaseClassWithTypes.cs
+++ b/CompulsoryCow.ReachIn/Tests/ReachInTestDotnetFramework/MyStaticBaseClassWithTypes.cs
@@ -1,4 +1,8 @@
-﻿namespace ReachInTestDotnetFramework
+﻿#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable CS0169 // Field is never used
+
+namespace ReachInTestDotnetFramework
 {
     public static class MyStaticBaseClassWithTypes
     {

--- a/CompulsoryCow.ReachIn/Tests/ReachPrivateInTestClassesDotnetFramework/MyClass.cs
+++ b/CompulsoryCow.ReachIn/Tests/ReachPrivateInTestClassesDotnetFramework/MyClass.cs
@@ -1,4 +1,7 @@
-﻿namespace ReachPrivateInTestClassesDotnetFramework
+﻿#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable CS0169 // Field is never used
+
+namespace ReachPrivateInTestClassesDotnetFramework
 {
     public class MyClass
     {

--- a/CompulsoryCow.ReachIn/Tests/ReachPrivateInTestClassesDotnetFramework/MyStaticClass.cs
+++ b/CompulsoryCow.ReachIn/Tests/ReachPrivateInTestClassesDotnetFramework/MyStaticClass.cs
@@ -1,4 +1,8 @@
-﻿namespace ReachPrivateInTestClassesDotnetFramework
+﻿#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable CS0169 // Field is never used
+
+namespace ReachPrivateInTestClassesDotnetFramework
 {
     public static class MyStaticClass
     {

--- a/CompulsoryCow.ReachIn/Tests/ReachPrivateInTestClassesDotnetStandard/MyClass.cs
+++ b/CompulsoryCow.ReachIn/Tests/ReachPrivateInTestClassesDotnetStandard/MyClass.cs
@@ -1,4 +1,7 @@
-﻿namespace ReachPrivateInTestClassesDotnetStandard
+﻿#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable CS0169 // Field is never used
+
+namespace ReachPrivateInTestClassesDotnetStandard
 {
     public class MyClass
     {

--- a/CompulsoryCow.ReachIn/Tests/ReachPrivateInTestClassesDotnetStandard/MyStaticClass.cs
+++ b/CompulsoryCow.ReachIn/Tests/ReachPrivateInTestClassesDotnetStandard/MyStaticClass.cs
@@ -1,4 +1,8 @@
-﻿namespace ReachPrivateInTestClassesDotnetStandard
+﻿#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable CS0169 // Field is never used
+
+namespace ReachPrivateInTestClassesDotnetStandard
 {
     public static class MyStaticClass
     {


### PR DESCRIPTION
This commit gets rid of some build warnings to make a cleaner output when compiling.

This commit is part of #72.