### PR TITLE
IsImplemented:Fix title in build script

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,7 +63,7 @@ jobs:
       with:
           PROJECT_FILE_PATH: CompulsoryCow.IsEqualsImplemented/CompulsoryCow.IsEqualsImplemented/CompulsoryCow.IsEqualsImplemented.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-    - name: Possibly publish CompulsoryCow.Meta
+    - name: Possibly publish CompulsoryCow.IsImplemented
       if: success() || failure()
       uses: brandedoutcast/publish-nuget@v2.5.5
       with:


### PR DESCRIPTION
This commit fixes a copy/paste error.

The nuget push did not succeed last time, so I doubt it will now.

This commit is a residue of #81.