### PR TITLE
IsImplemented:Use run script to deploy

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,10 +65,7 @@ jobs:
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
     - name: Possibly publish CompulsoryCow.IsImplemented
       if: success() || failure()
-      uses: brandedoutcast/publish-nuget@v2.5.5
-      with:
-          PROJECT_FILE_PATH: CompulsoryCow.IsImplemented/CompulsoryCow.IsImplemented/CompulsoryCow.IsImplemented.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+      run: nuget push **\CompulsoryCow.IsEqualsImplemented.*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
     - name: Possibly publish CompulsoryCow.Meta
       if: success() || failure()
       uses: brandedoutcast/publish-nuget@v2.5.5


### PR DESCRIPTION
As we cannot create a new nuget package from existing CI/CD-script, or with the present rights,  and brandedoutcase-/publish-nuget is deprecated
I try a new way, `run: nuget push...`.

This commit is part of #91.