### PR TITLE
IsImplemented:Set version 0.7

### DIFF
--- a/CompulsoryCow.IsImplemented/CompulsoryCow.IsImplemented/CompulsoryCow.IsImplemented.csproj
+++ b/CompulsoryCow.IsImplemented/CompulsoryCow.IsImplemented/CompulsoryCow.IsImplemented.csproj
@@ -5,6 +5,10 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+
+        <AssemblyVersion>0.7.0</AssemblyVersion>
+        <FileVersion>0.7.0</FileVersion>
+        <Version>0.7.0</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Last version mistakenly set version to 1.0.0.
I doubt I can upload a new nuget version 0.7 when 1.0 already has been uploaded. It might be that I can delete the package in nuget through the nuget cli but it only works on win.

This commit is part of #81